### PR TITLE
TMS-1178: Remove artist-pages image-gallery bottom-margin if the next block is text

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1178: Remove artist-pages image-gallery bottom-margin if the next block if text
+
 ## [1.0.0] - 2025-05-15
 
 - TMS-1138:

--- a/assets/styles/views/_single-artist.scss
+++ b/assets/styles/views/_single-artist.scss
@@ -1,2 +1,6 @@
 .single-artist {
+    // If a paragraph is the next element from image-gallery, remove the image-gallerys margin-bottom
+    .image-gallery:has(+ p) {
+        margin-bottom: 0 !important;
+    }
 }


### PR DESCRIPTION
Severa-ID: 2665
Severa-kuvaus: TMS-1178 Jazz Happening: Artisti-sisältötyyppiin kuvaajatieto
Task: https://hiondigital.atlassian.net/browse/TMS-1178

## Description
Remove artist-pages image-gallery bottom-margin if the next block is text, this allows the text block to contain photographers information and the text to be close to the image-gallery

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

