### PR TITLE
TMS-1190: Change hero height for wide monitors

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1190: Change hero height for wide monitors
+
 ## [1.1.1] - 2025-08-13
 
 - TMS-1160: Fix elements focus outline thickness

--- a/assets/styles/layouts/_hero.scss
+++ b/assets/styles/layouts/_hero.scss
@@ -42,6 +42,11 @@
                 max-height: 800px;
             }
 
+            @media (min-width: 2200px) {
+                height: 38vw;
+                max-height: none;
+            }
+
             h2,
             p {
                 color: $primary-invert;

--- a/assets/styles/views/_page.scss
+++ b/assets/styles/views/_page.scss
@@ -1,16 +1,21 @@
 .page {
     &__hero {
-        height: 35vh !important;
+        height: 35vh;
         background-position: top center;
 
         @include from($tablet) {
-            height: 50vh !important;
+            height: 50vh;
         }
 
         @include from($desktop) {
-            height: 80vh !important;
-            min-height: 500px !important;
-            max-height: 800px !important;
+            height: 80vh;
+            min-height: 500px;
+            max-height: 800px;
+        }
+
+        @media (min-width: 2200px) {
+            height: 38vw;
+            max-height: none;
         }
 
         .overlay {


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1190 Artikkelikuvien skaalautuminen meganäytöillä
Task: https://hiondigital.atlassian.net/browse/TMS-1190

## Description
Increase hero-image height for wide viewports to prevent images from cutting off

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

