### PR TITLE
TMS-1256: Add min-width for event filter select-elements

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1256: Add min-width for event filter select-elements
+
 ## [1.8.1] - 2026-02-22
 
 - TMS-1238: Fix page-artist search functionality

--- a/assets/styles/views/_event-search.scss
+++ b/assets/styles/views/_event-search.scss
@@ -78,6 +78,12 @@
         }
     }
 
+    @include from($tablet) {
+        .event-filter-column {
+            min-width: 300px;
+        }
+    }
+
     .event-filter-wrapper {
         position: relative;
 

--- a/partials/shared/events-list-filters.dust
+++ b/partials/shared/events-list-filters.dust
@@ -31,7 +31,7 @@
             <div class="pb-4">
                 <div class="columns filters">
                     {?days}
-                        <div class="column is-6-tablet is-3-desktop is-offset-3-desktop">
+                        <div class="column event-filter-column is-6-tablet is-3-desktop is-offset-3-desktop">
                             <div class="event-filter-wrapper mr-3">
                                 <label for="event-day" class="is-block h6 mb-1 is-sr-only">
                                     {filter_strings.day|html}
@@ -52,7 +52,7 @@
                     {/days}
 
                     {?event_order}
-                        <div class="column is-6-tablet is-3-desktop">
+                        <div class="column event-filter-column is-6-tablet is-3-desktop">
                             <div class="event-filter-wrapper mr-3">
                                 <label for="event-order" class="is-block h6 mb-1 is-sr-only">
                                     {filter_strings.change_order|html}

--- a/partials/shared/events-list-filters.dust
+++ b/partials/shared/events-list-filters.dust
@@ -29,9 +29,9 @@
     <div class="columns is-multiline">
         <div class="column">
             <div class="pb-4">
-                <div class="columns filters">
+                <div class="columns filters is-justify-content-center">
                     {?days}
-                        <div class="column event-filter-column is-6-tablet is-3-desktop is-offset-3-desktop">
+                        <div class="column event-filter-column is-6-tablet is-3-desktop">
                             <div class="event-filter-wrapper mr-3">
                                 <label for="event-day" class="is-block h6 mb-1 is-sr-only">
                                     {filter_strings.day|html}


### PR DESCRIPTION
Project: Tampereen kaupunki, konsernihallinto / Tietohallintoyksikkö
Project task: Tampere multisite support

Task: https://hiondigital.atlassian.net/browse/TMS-1256
Task title: Biennale ja Sävel: Tapahtumalistauksen suodatinvalikko vaaka-iPadissa

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add min-width for event filter select-elements to prevent them changing width by container width changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)